### PR TITLE
bugfix: show <img> images which aren't instance of HTMLCanvasElement

### DIFF
--- a/examples/jsm/interactive/HTMLMesh.js
+++ b/examples/jsm/interactive/HTMLMesh.js
@@ -260,7 +260,7 @@ function html2canvas( element ) {
 
 			return;
 
-		} else if ( element instanceof HTMLCanvasElement ) {
+		} else if ( element instanceof HTMLCanvasElement || element.tagName == 'IMG' ) {
 
 			// Canvas element
 			if ( element.style.display === 'none' ) return;


### PR DESCRIPTION
Not all images showed up. Now they do.

*This contribution is funded by caffeine*
